### PR TITLE
MAINT: Fix stack smashing and simplify setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,18 +5,7 @@ import pathlib
 import sysconfig
 from setuptools import setup, Extension
 
-
-def find_numpy_include():
-    """find numpy's include directory
-
-    Can't use np.get_include() when inside virtual environment
-    """
-    path = pathlib.Path(sys.prefix).joinpath("lib")
-    path = [*path.glob("python*")][0]
-    path = path.joinpath("site-packages/numpy/core/include")
-    if path.exists():
-        return path
-    raise RuntimeError("numpy include path not found")
+import numpy as np
 
 
 # pylint: disable=invalid-name
@@ -26,12 +15,7 @@ extensions = [
     Extension(
         name="npdt.customfloat",
         sources=["src/customfloat.c"],
-        depends=["src/customfloat.c"],
-        include_dirs=[
-            "src",
-            sysconfig.get_paths()["include"],
-            find_numpy_include(),
-        ],
+        include_dirs=[np.get_include(),],
         extra_compile_args=extra_compile_args,
     ),
 ]

--- a/src/customfloat.c
+++ b/src/customfloat.c
@@ -455,10 +455,10 @@ PyMODINIT_FUNC PyInit_customfloat(void)
     slots[4].slot = NPY_DT_discover_descr_from_pyobject;
     slots[4].pfunc = (void *)CustomFloatArray_discover_descr_from_pyobject;
     slots[5].slot = 0;
-    slots[6].pfunc = NULL;
+    slots[5].pfunc = NULL;
     PyArrayMethod_Spec *castingimpls[1];
     castingimpls[0] = NULL;
-    spec.casts = &castingimpls[0];
+    spec.casts = castingimpls;
 
     /* Create the dtype*/
     if (PyArrayInitDTypeMeta_FromSpec(&CustomFloat_DType, &spec) < 0)


### PR DESCRIPTION
This fixes the stack smashing.  Also uses `np.get_include()`
(for reasons I am not quite sure, I had to use `--no-build-isolation`
but then... I did not actually set up a clean virtual-env).