### PR TITLE
MAINT: Fixup promotion to work

### DIFF
--- a/src/float_dtype.c
+++ b/src/float_dtype.c
@@ -234,17 +234,15 @@ multiply_floats_resolve_descriptors(PyObject *method, PyObject *dtypes[3], PyObj
 static int
 promote_to_float(PyUFuncObject *ufunc, PyObject *dtypes[3], PyObject *signature[3], PyObject *new_dtypes[3])
 {
-    *new_dtypes = PyTuple_New(3);
-    Py_INCREF(new_dtypes);
-    for (Py_ssize_t i = 0; i < 3; i++)
+    for (int i = 0; i < 3; i++)
     {
-        PyObject *new = FloatSingleton;
+        PyObject *new = &PyArray_FloatDType;
         if (signature[i] != NULL)
         {
             new = signature[i];
         }
         Py_INCREF(new);
-        PyTuple_SetItem(new_dtypes, i, new);
+        new_dtypes[i] = new;
     }
     return 0;
 }

--- a/src/float_dtype.c
+++ b/src/float_dtype.c
@@ -193,7 +193,7 @@ pyfloat_to_from_float_resolve_descriptors(PyObject *NPY_UNUSED(method), PyArray_
     loop_descrs[1] = given_descrs[1];
     if (loop_descrs[1] == NULL)
     {
-        return -1;
+        loop_descrs[1] = FloatSingleton;
     }
     Py_INCREF(loop_descrs[1]);
     return NPY_NO_CASTING | _NPY_CAST_IS_VIEW;
@@ -419,7 +419,7 @@ PyInit_float_dtype(void)
     {
         goto fail;
     }
-    FloatSingleton = PyObject_New(PyArray_FloatDescr, (PyTypeObject *)&PyArray_FloatDType);
+    FloatSingleton = PyObject_CallNoArgs((PyObject *)&PyArray_FloatDType);
     if (FloatSingleton == NULL)
     {
         goto fail;


### PR DESCRIPTION
There were two issues:

1. The cast to "no dtype given" did not work.  The resolver has to support for the output to be `NULL` indicating that the user specified to cast to a FloatDType instance (but not which one!).
2. Promoters work with the DType classes only, promoters have no concept of the descriptors (dtype instances).  The C promoter also does not use tuples.